### PR TITLE
ユーザ一括フォロー機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,3 +46,5 @@ end
 
 # Windows ではタイムゾーン情報用の tzinfo-data gem を含める必要があります
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem 'ransack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,6 +191,10 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.20.3, < 2.0)
     rake (12.3.3)
+    ransack (3.0.1)
+      activerecord (>= 6.0.4)
+      activesupport (>= 6.0.4)
+      i18n
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -283,6 +287,7 @@ DEPENDENCIES
   puma (= 4.3.6)
   rails (= 6.0.4)
   rails-controller-testing (= 1.0.4)
+  ransack
   sass-rails (= 5.1.0)
   selenium-webdriver (= 3.142.4)
   spring (= 2.1.0)

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -3,7 +3,7 @@ class RelationshipsController < ApplicationController
 
   def create
     @user = User.find(params[:followed_id])
-    current_user.follow(@user)
+    current_user.follow(@user) # current_userが@userをフォロー
     respond_to do |format|
       format.html { redirect_to @user }
       format.js
@@ -17,5 +17,17 @@ class RelationshipsController < ApplicationController
       format.html { redirect_to @user }
       format.js
     end
+  end
+
+  def create_all
+    users_id_list = params[:users].keys # チェックされたユーザのidを配列に格納
+
+    users_id_list.each |id| do # 配列に含まれるユーザを1人ずつフォロー
+      user = User.find(id)
+      #current_user.follow(User.find(params[:id]))
+      current_user.active_relationships.build(followed_id: user.id)
+    end
+
+    redirect_to users_path
   end
 end

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -20,14 +20,20 @@ class RelationshipsController < ApplicationController
   end
 
   def create_all
-    users_id_list = params[:users].keys # チェックされたユーザのidを配列に格納
-
-    users_id_list.each |id| do # 配列に含まれるユーザを1人ずつフォロー
-      user = User.find(id)
-      #current_user.follow(User.find(params[:id]))
-      current_user.active_relationships.build(followed_id: user.id)
+    respond_to do |format|
+      if params[:users].nil? # チェックがない場合
+        format.html { redirect_to users_path }
+      else # チェックされたユーザを一括フォロー
+        users_id_list = params[:users].map(&:to_i) # チェックされたユーザのidをint型で配列に格納
+        users_id_list.each do |id| # 配列に含まれるユーザを1人ずつフォロー
+          if current_user.following.ids.include?(id) # チェックされたユーザをすでにフォローしていたら次のidへ
+            next
+          end
+          user = User.find(id)
+          current_user.follow(user)
+        end
+        format.html { redirect_to users_path }
+      end
     end
-
-    redirect_to users_path
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,8 @@ class UsersController < ApplicationController
   before_action :admin_user, only: [:destroy]
 
   def index
-    @users = User.paginate(page: params[:page])
+    @q = User.ransack(params[:q])
+    @users = @q.result(distinct: true).page(params[:page])
   end
 
   def show

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,10 @@
 class User < ApplicationRecord
   has_many :microposts, dependent: :destroy
+  # フォローしてるユーザ
   has_many :active_relationships, class_name: 'Relationship',
            foreign_key: "follower_id",
            dependent: :destroy
+  # フォローされているユーザ
   has_many :passive_relationships, class_name: "Relationship",
            foreign_key: 'followed_id',
            dependent: :destroy
@@ -76,7 +78,7 @@ class User < ApplicationRecord
   end
 
   def follow(other_user)
-    following << other_user
+    following << other_user # folling配列の最後にother_userを入れる
   end
 
   def unfollow(other_user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -89,6 +89,14 @@ class User < ApplicationRecord
     following.include?(other_user)
   end
 
+  def self.ransackable_attributes(auth_object = nil)
+    %w[name]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    []
+  end
+
   private
 
   def downcase_email

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,11 +1,15 @@
 <% provide(:title, 'All users') %>
 <h1>All users</h1>
 
+<%= search_form_for @q do |f| %>
+  <%= f.search_field :name_cont, placeholder: 'user name' %>
+  <%= f.submit class: 'btn btn-primary' %>
+<% end %>
+
 <%= will_paginate %>
 
 <%= form_with(url: create_all_relationships_path, local: true) do |f| %>
-  <%= f.submit '一括フォロー', class: 'button' %> 
-
+  <%= f.submit 'Follow selected user', class: 'button' %> 
   <ul class="users">
     <% @users.each do |user| %>
       <li>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -3,7 +3,7 @@
 
 <%= will_paginate %>
 
-<%= form_with(url: relationship_follow_all, local: true) do |f| %>
+<%= form_with(url: relationship_follow_all_path, local: true) do |f| %>
   <%= f.submit '一括フォロー', class: 'button' %> 
 
   <ul class="users">

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -3,9 +3,21 @@
 
 <%= will_paginate %>
 
-<ul class="users">
-  <%= render @users%>
-</ul>
+<%= form_with(url: relationship_c_all_path, local: true) do |f| %>
+  <%= f.submit '一括フォロー', class: 'button' %> 
 
+  <ul class="users">
+    <% @users.each do |user| %>
+      <li>
+        <%= gravatar_for user, size: 50 %>
+        <%= link_to user.name, user %>
+        <%= check_box_tag 'users[]', user.id %>
+        <% if current_user.admin? && !current_user?(user) %>
+          | <%= link_to "delete", user, method: :delete,
+                        data: { confirm: "You sure?" } %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>
 <%= will_paginate %>
-

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -3,7 +3,7 @@
 
 <%= will_paginate %>
 
-<%= form_with(url: relationship_c_all_path, local: true) do |f| %>
+<%= form_with(url: relationship_follow_all, local: true) do |f| %>
   <%= f.submit '一括フォロー', class: 'button' %> 
 
   <ul class="users">

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -3,7 +3,7 @@
 
 <%= will_paginate %>
 
-<%= form_with(url: relationship_follow_all_path, local: true) do |f| %>
+<%= form_with(url: create_all_relationships_path, local: true) do |f| %>
   <%= f.submit '一括フォロー', class: 'button' %> 
 
   <ul class="users">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,5 +16,7 @@ Rails.application.routes.draw do
   resources :account_activations, only: [:edit]
   resources :password_resets,     only: [:new, :create, :edit, :update]
   resources :microposts,          only: [:create, :destroy]
-  resources :relationships,       only: [:create, :destroy]
+  resources :relationships do
+    post :c_all, to: 'relationships#create_all'
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,6 @@ Rails.application.routes.draw do
   resources :password_resets,     only: [:new, :create, :edit, :update]
   resources :microposts,          only: [:create, :destroy]
   resources :relationships do
-    post :c_all, to: 'relationships#create_all'
+    post :follow_all, to: 'relationships#create_all'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
   resources :password_resets,     only: [:new, :create, :edit, :update]
   resources :microposts,          only: [:create, :destroy]
   resources :relationships do
-    post :follow_all, to: 'relationships#create_all'
+    collection do
+      post 'create_all'
+    end
   end
 end


### PR DESCRIPTION
## 実装背景
https://github.com/medpeer-dev/rails_tutorial6/issues/6

## やったこと
- [x] relationshipscontroller.rbに選択されたユーザを一括フォローするcrete_allメソッドを作成
- [x] ユーザ一覧画面でcheck_box_tagを用いて選択されたユーザをidを保持する
- [x] ransackを用いてユーザ検索機能を作成

## 一括フォローのエビデンス
[ice_video_20220905-172837.webm](https://user-images.githubusercontent.com/112373209/188404680-68d34ce4-9dc7-4f6b-9195-f6a0754320f7.webm)

## 検索結果からフォローのエビデンス
[ice_video_20220905-173310.webm](https://user-images.githubusercontent.com/112373209/188405545-735a2ff5-4a89-4b3d-b630-1611b869bf5c.webm)

## 未着手
- 機能のテスト